### PR TITLE
fix 从助记词创建wallet对象

### DIFF
--- a/04_SendETH/SendETH.js
+++ b/04_SendETH/SendETH.js
@@ -17,7 +17,8 @@ const privateKey = '0x227dbb8586117d55284e26620bc76534dfbd2394be34cf4a09cb775d59
 const wallet2 = new ethers.Wallet(privateKey, provider)
 
 // 从助记词创建wallet对象
-const wallet3 = new ethers.Wallet.fromMnemonic(mnemonic.phrase)
+const wallet3Mnemonic= new ethers.Wallet.fromMnemonic(mnemonic.phrase)
+const wallet3 = new Wallet(wallet3Mnemonic.privateKey, provider)
 
 const main = async () => {
     // 1. 获取钱包地址


### PR DESCRIPTION
https://docs.ethers.org/v5/api/signer/#Wallet.fromMnemonic

fromMnemonic api返回的是一个助记词实例而不是钱包实例