### PR TITLE
flashbot依赖ethers5,导致代码不能运行

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,6 @@
             "version": "1.0.0",
             "license": "MIT",
             "dependencies": {
-                "@flashbots/ethers-provider-bundle": "^0.6.1",
                 "ethers": "^6.2.3",
                 "merkletreejs": "^0.2.32"
             }
@@ -18,14 +17,6 @@
             "version": "1.9.0",
             "resolved": "https://registry.npmjs.org/@adraffy/ens-normalize/-/ens-normalize-1.9.0.tgz",
             "integrity": "sha512-iowxq3U30sghZotgl4s/oJRci6WPBfNO5YYgk2cIOMCHr3LeGPcsZjCEr+33Q4N+oV3OABDAtA+pyvWjbvBifQ=="
-        },
-        "node_modules/@flashbots/ethers-provider-bundle": {
-            "version": "0.6.1",
-            "resolved": "https://registry.npmjs.org/@flashbots/ethers-provider-bundle/-/ethers-provider-bundle-0.6.1.tgz",
-            "integrity": "sha512-W7tSX832mi7XKlbg4dIMzV1HMw5Dg0ox0YOqPxW2nO2JqsAZwWYFrAk4nNZnsqRdexHiPF4JUYez/ELI5VpScA==",
-            "peerDependencies": {
-                "ethers": "5.7.2"
-            }
         },
         "node_modules/@noble/hashes": {
             "version": "1.1.2",
@@ -641,12 +632,6 @@
             "version": "1.9.0",
             "resolved": "https://registry.npmjs.org/@adraffy/ens-normalize/-/ens-normalize-1.9.0.tgz",
             "integrity": "sha512-iowxq3U30sghZotgl4s/oJRci6WPBfNO5YYgk2cIOMCHr3LeGPcsZjCEr+33Q4N+oV3OABDAtA+pyvWjbvBifQ=="
-        },
-        "@flashbots/ethers-provider-bundle": {
-            "version": "0.6.1",
-            "resolved": "https://registry.npmjs.org/@flashbots/ethers-provider-bundle/-/ethers-provider-bundle-0.6.1.tgz",
-            "integrity": "sha512-W7tSX832mi7XKlbg4dIMzV1HMw5Dg0ox0YOqPxW2nO2JqsAZwWYFrAk4nNZnsqRdexHiPF4JUYez/ELI5VpScA==",
-            "requires": {}
         },
         "@noble/hashes": {
             "version": "1.1.2",

--- a/package.json
+++ b/package.json
@@ -9,7 +9,6 @@
     "author": "0xAA",
     "license": "MIT",
     "dependencies": {
-        "@flashbots/ethers-provider-bundle": "^0.6.1",
         "ethers": "^6.2.3",
         "merkletreejs": "^0.2.32"
     }


### PR DESCRIPTION
`@flashbots/ethers-provider-bundle` 依赖 `ethers:5.7.2`, 且暂没有版本支持`ethers 6+`. 有此依赖会导致代码无法正常运行，因此暂时去掉该依赖。会影响第25讲[Flashbots](https://github.com/WTFAcademy/WTF-Ethers/tree/main/25_Flashbots)