### PR TITLE
update 11_StaticCall readme.md

### DIFF
--- a/11_StaticCall/readme.md
+++ b/11_StaticCall/readme.md
@@ -97,7 +97,7 @@ tags:
     ```js
     console.log("\n2.  用staticCall尝试调用transfer转账1 DAI，msg.sender为V神地址")
     // 发起交易
-    const tx = await contractDAI.transfer.staticCall("vitalik.eth", ethers.parseEther("10000"), {from:  await provider.resolveName("vitalik.eth")})
+    const tx = await contractDAI.transfer.staticCall("vitalik.eth", ethers.parseEther("1"), {from:  await provider.resolveName("vitalik.eth")})
     console.log(`交易会成功吗？：`, tx)
     ```
     ![模拟V神转账](img/11-3.png)

--- a/11_StaticCall/readme.md
+++ b/11_StaticCall/readme.md
@@ -45,7 +45,7 @@ tags:
 
 - 函数名：为模拟调用的函数名。
 - 参数：调用函数的参数。
-- {override}：选填，可包含一下参数：
+- {override}：选填，可包含以下参数：
     - `from`：执行时的`msg.sender`，也就是你可以模拟任何一个人的调用，比如V神。
     - `value`：执行时的`msg.value`。
     - `blockTag`：执行时的区块高度。
@@ -97,7 +97,7 @@ tags:
     ```js
     console.log("\n2.  用staticCall尝试调用transfer转账1 DAI，msg.sender为V神地址")
     // 发起交易
-    const tx = await contractDAI.transfer.staticCall("vitalik.eth", ethers.parseEther("10000"), {from: "vitalik.eth"})
+    const tx = await contractDAI.transfer.staticCall("vitalik.eth", ethers.parseEther("10000"), {from:  await provider.resolveName("vitalik.eth")})
     console.log(`交易会成功吗？：`, tx)
     ```
     ![模拟V神转账](img/11-3.png)

--- a/12_ERC721Check/readme.md
+++ b/12_ERC721Check/readme.md
@@ -64,7 +64,7 @@ interface IERC165 {
     ```js
     //准备 alchemy API 可以参考https://github.com/AmazingAng/WTFSolidity/blob/main/Topics/Tools/TOOL04_Alchemy/readme.md 
     const ALCHEMY_MAINNET_URL = 'https://eth-mainnet.g.alchemy.com/v2/oKmOQKbneVkxgHZfibs-iFhIlIAl6HDN';
-    const provider = new ethers.providers.JsonRpcProvider(ALCHEMY_MAINNET_URL);
+    const provider = new ethers.JsonRpcProvider(ALCHEMY_MAINNET_URL);
     ```
 
 2. 创建`ERC721`合约实例，在`abi`接口中，我们声明要使用的`name()`，`symbol()`，和`supportsInterface()`函数即可。这里我们用的BAYC的合约地址。


### PR DESCRIPTION
1. Fix description error;
2. Fix the error:

> Error: ENS resolution requires a provider (operation="resolveName", code=UNSUPPORTED_OPERATION, version=6.7.1)

 caused by line `const tx = await contractDAI.transfer.staticCall("vitalik.eth", ethers.parseEther("10000"), {from: "vitalik.eth"})`
An error is reported when the `from` parameter is a ENS domain, which should be an address.




