### PR TITLE
Update 20_DecodeTx

### DIFF
--- a/20_DecodeTx/DecodeTx.js
+++ b/20_DecodeTx/DecodeTx.js
@@ -12,11 +12,12 @@ const contractABI = [
 ]
 const iface = new ethers.Interface(contractABI)
 
-// 3. 获取函数签名。
-const selector = iface.getFunction("transfer")
+// 3. 获取函数选择器。
+const selector = iface.getFunction("transfer").selector
 console.log(`函数选择器是${selector}`)
 
 // 4. 监听pending的erc20 transfer交易，获取交易详情，然后解码。
+// 处理bigInt
 function handleBigInt(key, value) {
     if (typeof value === "bigint") {
         return value.toString() + "n"; // or simply return value.toString();

--- a/20_DecodeTx/DecodeTx.js
+++ b/20_DecodeTx/DecodeTx.js
@@ -10,14 +10,20 @@ network.then(res => console.log(`[${(new Date).toLocaleTimeString()}]连接到ch
 const contractABI = [
     "function transfer(address, uint) public returns (bool)",
 ]
-const iface = new ethers.utils.Interface(contractABI)
+const iface = new ethers.Interface(contractABI)
 
 // 3. 获取函数签名。
-const functionSignature = 'transfer(address,uint)'
-const selector = iface.getSighash(functionSignature)
+const selector = iface.getFunction("transfer")
 console.log(`函数选择器是${selector}`)
 
 // 4. 监听pending的erc20 transfer交易，获取交易详情，然后解码。
+function handleBigInt(key, value) {
+    if (typeof value === "bigint") {
+        return value.toString() + "n"; // or simply return value.toString();
+    }
+    return value;
+}
+
 let j = 0
 provider.on('pending', async (txHash) => {
     if (txHash) {
@@ -25,9 +31,9 @@ provider.on('pending', async (txHash) => {
         j++
         if (tx !== null && tx.data.indexOf(selector) !== -1) {
             console.log(`[${(new Date).toLocaleTimeString()}]监听到第${j + 1}个pending交易:${txHash}`)
-            console.log(`打印解码交易详情:${JSON.stringify(iface.parseTransaction(tx), null, 2)}`)
+            console.log(`打印解码交易详情:${JSON.stringify(iface.parseTransaction(tx), handleBigInt, 2)}`)
             console.log(`转账目标地址:${iface.parseTransaction(tx).args[0]}`)
-            console.log(`转账金额:${ethers.utils.formatEther(iface.parseTransaction(tx).args[1])}`)
+            console.log(`转账金额:${ethers.formatEther(iface.parseTransaction(tx).args[1])}`)
             provider.removeListener('pending', this)
         }
     }

--- a/20_DecodeTx/readme.md
+++ b/20_DecodeTx/readme.md
@@ -74,14 +74,14 @@ const iface = ethers.Interface([
 3. 获取函数选择器。
 
     ```js
-    const selector = iface.getFunction("transfer")
+    const selector = iface.getFunction("transfer").selector
     console.log(`函数选择器是${selector}`)
     ```
 
 4. 监听`pending`的`ERC20` 转账交易，获取交易详情并解码：
 
     ```js
-    // 处理bitInt
+    // 处理bigInt
     function handleBigInt(key, value) {
         if (typeof value === "bigint") {
             return value.toString() + "n"; // or simply return value.toString();
@@ -111,4 +111,4 @@ const iface = ethers.Interface([
 
 ## 总结
 
-这一讲，我们介绍了`ethers.js`的`Interface`类，并利用它解码了`mempool`中的`Transfer`交易。
+这一讲，我们介绍了`ethers.js`的`Interface`类，并利用它解码了`mempool`中的`transfer`交易。

--- a/20_DecodeTx/readme.md
+++ b/20_DecodeTx/readme.md
@@ -74,23 +74,30 @@ const iface = ethers.Interface([
 3. 获取函数选择器。
 
     ```js
-    const functionSignature = 'transfer(address,uint)'
-    const selector = iface.getSighash(functionSignature)
+    const selector = iface.getFunction("transfer")
     console.log(`函数选择器是${selector}`)
     ```
 
 4. 监听`pending`的`ERC20` 转账交易，获取交易详情并解码：
 
     ```js
-    rovider.on('pending', async (txHash) => {
+    // 处理bitInt
+    function handleBigInt(key, value) {
+        if (typeof value === "bigint") {
+            return value.toString() + "n"; // or simply return value.toString();
+        }
+    return value;
+    }
+    
+    provider.on('pending', async (txHash) => {
     if (txHash) {
         const tx = await provider.getTransaction(txHash)
         j++
         if (tx !== null && tx.data.indexOf(selector) !== -1) {
             console.log(`[${(new Date).toLocaleTimeString()}]监听到第${j + 1}个pending交易:${txHash}`)
-            console.log(`打印解码交易详情:${JSON.stringify(iface.parseTransaction(tx), null, 2)}`)
+            console.log(`打印解码交易详情:${JSON.stringify(iface.parseTransaction(tx), handleBigInt, 2)}`)
             console.log(`转账目标地址:${iface.parseTransaction(tx).args[0]}`)
-            console.log(`转账金额:${ethers.utils.formatEther(iface.parseTransaction(tx).args[1])}`)
+            console.log(`转账金额:${ethers.formatEther(iface.parseTransaction(tx).args[1])}`)
             provider.removeListener('pending', this)
         }
     }})
@@ -104,4 +111,4 @@ const iface = ethers.Interface([
 
 ## 总结
 
-这一讲，我们介绍了`ethers.js`的`Interface`类，并利用它解码了`mempool`中的`Uniswap`交易。
+这一讲，我们介绍了`ethers.js`的`Interface`类，并利用它解码了`mempool`中的`Transfer`交易。


### PR DESCRIPTION
1.Ethers v6中获取函数选择器为：`interface.getFunction("funName").selector`

> 参考：https://github.com/ethers-io/ethers.js/discussions/3893

2.打印解码交易详情时加入`handleBigInt`函数，避免`JSON.stringify`转换数据时出现`BigInt`类型报错
```
> `打印解码交易详情: ${JSON.stringify(
>                           ^
> 
> TypeError: Do not know how to serialize a BigInt
>     at JSON.stringify (<anonymous>)
```
3.替换一些v6中已弃用的方法 