### PR TITLE
fix(01_HelloVitalik): 修复en中的ethers引入方式以及增加注释

### DIFF
--- a/01_HelloVitalik/HelloVitalik.js
+++ b/01_HelloVitalik/HelloVitalik.js
@@ -5,12 +5,14 @@ import { ethers } from "ethers";
 
 // 利用ethers默认的Provider连接以太坊网络
 // const provider = new ethers.getDefaultProvider();
-const ALCHEMY_MAINNET_URL = 'https://eth-mainnet.g.alchemy.com/v2/oKmOQKbneVkxgHZfibs-iFhIlIAl6HDN';
+// 注意：如果当前的URL无法使用，需要主动去NFURA或者ALCHEMY官网注册并获得URl
+const ALCHEMY_MAINNET_URL = "https://eth-mainnet.g.alchemy.com/v2/oKmOQKbneVkxgHZfibs-iFhIlIAl6HDN";
 const provider = new ethers.JsonRpcProvider(ALCHEMY_MAINNET_URL)
 
 const main = async () => {
-    // 查询vitalik的ETH余额
-    const balance = await provider.getBalance(`vitalik.eth`);
-    // 将余额输出在console
-    console.log(`ETH Balance of vitalik: ${ethers.formatEther(balance)} ETH`);}
+  // 查询vitalik的ETH余额
+  const balance = await provider.getBalance(`vitalik.eth`); //0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045
+  // 将余额输出在console
+  console.log(`ETH Balance of vitalik: ${ethers.formatEther(balance)} ETH`);
+}
 main()

--- a/01_HelloVitalik/HelloVitalik.js
+++ b/01_HelloVitalik/HelloVitalik.js
@@ -7,12 +7,12 @@ import { ethers } from "ethers";
 // const provider = new ethers.getDefaultProvider();
 // 注意：如果当前的URL无法使用，需要主动去NFURA或者ALCHEMY官网注册并获得URl
 const ALCHEMY_MAINNET_URL = "https://eth-mainnet.g.alchemy.com/v2/oKmOQKbneVkxgHZfibs-iFhIlIAl6HDN";
-const provider = new ethers.JsonRpcProvider(ALCHEMY_MAINNET_URL)
+const provider = new ethers.JsonRpcProvider(ALCHEMY_MAINNET_URL);
 
 const main = async () => {
   // 查询vitalik的ETH余额
   const balance = await provider.getBalance(`vitalik.eth`); //0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045
   // 将余额输出在console
   console.log(`ETH Balance of vitalik: ${ethers.formatEther(balance)} ETH`);
-}
-main()
+};
+main();

--- a/en/01_HelloVitalik/HelloVitalik.js
+++ b/en/01_HelloVitalik/HelloVitalik.js
@@ -5,7 +5,7 @@ import { ethers } from "ethers";
 
 // Connect to the Ethereum network using any desired provider (e.g INFURA or ALCHEMY) 
 // const provider = new ethers.JsonRpcProvider();
-// Note: if the current URL cannot be used, you need to register at NFURA or ALCHEMY's official website and get URL by yourself.
+// Note: if the current URL cannot be used, you need to register at INFURA or ALCHEMY's official website and get URL by yourself.
 const provider = new ethers.JsonRpcProvider(`https://mainnet.infura.io/v3/8b9750710d56460d940aeff47967c4ba`)
 // Specify the address you want to query
 const address = '0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045' //or 'vitalik.eth'

--- a/en/01_HelloVitalik/HelloVitalik.js
+++ b/en/01_HelloVitalik/HelloVitalik.js
@@ -1,10 +1,11 @@
 // Import the ethers package
-const { ethers } = require("ethers");
+import { ethers } from "ethers";
 // playcode's free version cannot install ethers, use this command to import the package from the internet (comment out the line above)
 // import { ethers } from "https://cdnjs.cloudflare.com/ajax/libs/ethers/6.2.3/ethers.js";
 
 // Connect to the Ethereum network using any desired provider (e.g INFURA or ALCHEMY) 
 // const provider = new ethers.JsonRpcProvider();
+// Note: if the current URL cannot be used, you need to register at NFURA or ALCHEMY's official website and get URL by yourself.
 const provider = new ethers.JsonRpcProvider(`https://mainnet.infura.io/v3/8b9750710d56460d940aeff47967c4ba`)
 // Specify the address you want to query
 const address = '0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045' //or 'vitalik.eth'

--- a/en/01_HelloVitalik/HelloVitalik.js
+++ b/en/01_HelloVitalik/HelloVitalik.js
@@ -3,17 +3,19 @@ import { ethers } from "ethers";
 // playcode's free version cannot install ethers, use this command to import the package from the internet (comment out the line above)
 // import { ethers } from "https://cdnjs.cloudflare.com/ajax/libs/ethers/6.2.3/ethers.js";
 
-// Connect to the Ethereum network using any desired provider (e.g INFURA or ALCHEMY) 
+// Connect to the Ethereum network using any desired provider (e.g INFURA or ALCHEMY)
 // const provider = new ethers.JsonRpcProvider();
 // Note: if the current URL cannot be used, you need to register at INFURA or ALCHEMY's official website and get URL by yourself.
-const provider = new ethers.JsonRpcProvider(`https://mainnet.infura.io/v3/8b9750710d56460d940aeff47967c4ba`)
+const provider = new ethers.JsonRpcProvider(
+  `https://mainnet.infura.io/v3/8b9750710d56460d940aeff47967c4ba`,
+);
 // Specify the address you want to query
-const address = '0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045' //or 'vitalik.eth'
+const address = "0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045"; //or 'vitalik.eth'
 
 const main = async () => {
-    // Query the ETH balance of vitalik
-      const balance = await provider.getBalance(address) //or 'vitalik.eth'
-    // Output the balance to the console
-      console.log(`\nETH Balance of ${address} --> ${ethers.formatEther(balance)} ETH\n`)
-        }
-main()
+  // Query the ETH balance of vitalik
+  const balance = await provider.getBalance(address); //or 'vitalik.eth'
+  // Output the balance to the console
+  console.log(`\nETH Balance of ${address} --> ${ethers.formatEther(balance)} ETH\n`);
+};
+main();


### PR DESCRIPTION
- en/01_HelloVitalik中的`ethers`引入方式修复
- 01_HelloVitalik中目前使用的 `INFURA` 或者 `ALCHEMY` 的 `URL` 不可用，所以增加注释建议学员去申请自己的 `URL`