### PR TITLE
删掉不必要代码L70

### DIFF
--- a/23_Frontrun/frontrun.js
+++ b/23_Frontrun/frontrun.js
@@ -67,7 +67,7 @@ const frontRun = async () => {
             console.log(`frontrun 交易成功,交易hash是:${receipt.transactionHash}`)
             console.log(`铸造发起的地址是:${tx.from}`)
             console.log(`编号${aimTokenId}NFT的持有者是${await contractFM.ownerOf(aimTokenId)}`)//刚刚mint的nft持有者并不是tx.from
-            console.log(`编号${aimTokenId.add(1)}的NFT的持有者是:${await contractFM.ownerOf(aimTokenId.add(1))}`)//tx.from被wallet.address抢跑，mint了下一个nft
+  
             console.log(`铸造发起的地址是不是对应NFT的持有者:${tx.from === await contractFM.ownerOf(aimTokenId)}`)//比对地址，tx.from被抢跑
             //检验区块内数据结果
             const block = await provider.getBlock(tx.blockNumber)


### PR DESCRIPTION
Ethers第23讲《抢跑交易》，L7代码是错的(或者多余）:           

console.log(`编号${aimTokenId.add(1)}的NFT的持有者是:${await contractFM.ownerOf(aimTokenId.add(1))}`) // tx.from被wallet.address抢跑，mint了下一个nft

理论上，抢跑交易成功后，aimTokenId.add(1)还没有被mint, 不存在onwer, 所以contractFM.ownerOf(aimTokenId.add(1))是一个空值，测试了很多次都会报错，建议删掉，不影响整段代码逻辑。