### PR TITLE
Fix: HDNodeWalleth创建方式错误导致钱包恢复地址不一致bug修复

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,5 @@
 node_modules
 server.js
 Test
+.vscode
+.wake

--- a/14_HDwallet/HDwallet.js
+++ b/14_HDwallet/HDwallet.js
@@ -6,8 +6,8 @@ console.log("\n1. 创建HD钱包")
 const mnemonic = ethers.Mnemonic.entropyToPhrase(ethers.randomBytes(32))
 // 创建HD基钱包
 // 基路径："m / purpose' / coin_type' / account' / change"
-const basePath = "44'/60'/0'/0"
-const baseWallet = ethers.HDNodeWallet.fromPhrase(mnemonic, basePath)
+const basePath = "m/44'/60'/0'/0"
+const baseWallet = ethers.HDNodeWallet.fromPhrase(mnemonic, null, basePath)
 console.log(baseWallet);
 
 // 2. 通过HD钱包派生20个钱包
@@ -25,7 +25,7 @@ for (let i = 0; i < numWallet; i++) {
 
 // 3. 保存钱包（加密json）
 console.log("\n3. 保存钱包（加密json）")
-const wallet = ethers.Wallet.fromPhrase(mnemonic)
+const wallet = ethers.HDNodeWallet.fromPhrase(mnemonic, null, basePath)
 console.log("通过助记词创建钱包：")
 console.log(wallet)
 // 加密json用的密码，可以更改成别的


### PR DESCRIPTION
Fixes #188 
✅ 主要变更
	1.	修复 HD 钱包路径设置
将原本错误的路径 "44'/60'/0'/0" 更正为符合 BIP44 标准的路径 "m/44'/60'/0'/0"。
	2.	调整 fromPhrase 的使用方式
原代码未传入完整的路径参数，本次更新中通过 ethers.HDNodeWallet.fromPhrase(mnemonic, null, basePath) 显式传入路径，确保派生地址一致性。
	3.	  ##优化加密钱包的创建与读取逻辑
使用 HDNodeWallet.fromPhrase(...) 代替 Wallet.fromPhrase(...) 创建主钱包，保持一致性。

📦 影响范围
	•	HDNodeWallet 创建与派生逻辑
	•	加密钱包的导出与导入逻辑

🧪 测试说明
	•	能正确导出加密 JSON，并用密码恢复钱包。
	•	所有钱包地址与预期路径匹配。